### PR TITLE
Reduce bytecode size

### DIFF
--- a/base.js
+++ b/base.js
@@ -7,28 +7,33 @@ mat4.random = function() {
 
 var config = {
     runCount : 20,
-    internalRunCount : 500000
+    internalRunCount : 500000,
+    numMatrices: 500
 }
 
 var tests = [
   { name : 'Invert',
-    scalarFunc: function(count) {
-        var m = mat4.random();
+    scalarFunc: function(count, matrices) {
         var out = new Float32Array(16);
-        var start = Date.now();
+        var time = 0;
         for (var i = 0; i < count; ++i) {
+            var m = matrices[i % matrices.length]
+            var start = Date.now();
             mat4.scalar.invert(out, m);
+            time += Date.now() - start;
         }
-        return Date.now()-start;
+        return time;
     },
-    simdFunc: function(count) {
-        var m = mat4.random();
+    simdFunc: function(count, matrices) {
         var out = new Float32Array(16);
-        var start = Date.now();
+        var time = 0;
         for (var i = 0; i < count; ++i) {
+            var start = Date.now();
+            var m = matrices[i % matrices.length]
             mat4.SIMD.invert(out, m);
+            time += Date.now() - start;
         }
-        return Date.now()-start;
+        return time;
    }
  },
   { name : 'Scale',
@@ -169,8 +174,13 @@ function runTest(name, f) {
   var minTime = +Infinity;
   var maxTime = -Infinity;
 
+  var matrices = [];
+  for (var i = 0; i < config.numMatrices; ++i) {
+      matrices[i] = mat4.random();
+  }
+
   for(var i = 0; i < config.runCount; ++i) {
-    var time = f(config.internalRunCount);
+    var time = f(config.internalRunCount, matrices);
     minTime = Math.min(minTime, time);
     maxTime = Math.max(maxTime, time);
     totalTime += time;

--- a/base.js
+++ b/base.js
@@ -166,18 +166,13 @@ var tests = [
 function runTest(name, f) {
 
   var totalTime = 0;
-  var minTime = 0;
-  var maxTime = 0;
+  var minTime = +Infinity;
+  var maxTime = -Infinity;
 
   for(var i = 0; i < config.runCount; ++i) {
     var time = f(config.internalRunCount);
-    if(i == 0) {
-      minTime = time;
-      maxTime = time;
-    } else {
-      if(minTime > time) { minTime = time; }
-      if(maxTime < time) { maxTime = time; }
-    }
+    minTime = Math.min(minTime, time);
+    maxTime = Math.max(maxTime, time);
     totalTime += time;
   }
 

--- a/base.js
+++ b/base.js
@@ -36,6 +36,7 @@ var tests = [
         return time;
    }
  },
+ /*
   { name : 'Scale',
     scalarFunc: function(count) {
         var m = mat4.random();
@@ -166,7 +167,7 @@ var tests = [
       }
       return Date.now()-start;
  }
-}];
+}*/];
 
 function runTest(name, f) {
 
@@ -192,7 +193,7 @@ function runTest(name, f) {
 
 function runTests(kernels) {
     for(var i = 0; i < kernels.length; ++i){
-        runTest(kernels[i].name + " (Scalar)", kernels[i].scalarFunc);
+        //runTest(kernels[i].name + " (Scalar)", kernels[i].scalarFunc);
         runTest(kernels[i].name + " (SIMD)", kernels[i].simdFunc);
     }
 }

--- a/gl-matrix.js
+++ b/gl-matrix.js
@@ -1682,91 +1682,98 @@ return /******/ (function(modules) { // webpackBootstrap
 	      tmp1,
 	      minor0, minor1, minor2, minor3,
 	      det,
-	      a0 = SIMD.Float32x4.load(a, 0),
-	      a1 = SIMD.Float32x4.load(a, 4),
-	      a2 = SIMD.Float32x4.load(a, 8),
-	      a3 = SIMD.Float32x4.load(a, 12);
+          LOAD = SIMD.Float32x4.load,
+          STORE = SIMD.Float32x4.store,
+          SH = SIMD.Float32x4.shuffle,
+          SW = SIMD.Float32x4.swizzle,
+          SUB = SIMD.Float32x4.sub,
+          ADD = SIMD.Float32x4.add,
+          M = SIMD.Float32x4.mul;
+	  var a0 = LOAD(a, 0),
+	      a1 = LOAD(a, 4),
+	      a2 = LOAD(a, 8),
+	      a3 = LOAD(a, 12);
 
 	  // Compute matrix adjugate
-	  tmp1 = SIMD.Float32x4.shuffle(a0, a1, 0, 1, 4, 5);
-	  row1 = SIMD.Float32x4.shuffle(a2, a3, 0, 1, 4, 5);
-	  row0 = SIMD.Float32x4.shuffle(tmp1, row1, 0, 2, 4, 6);
-	  row1 = SIMD.Float32x4.shuffle(row1, tmp1, 1, 3, 5, 7);
-	  tmp1 = SIMD.Float32x4.shuffle(a0, a1, 2, 3, 6, 7);
-	  row3 = SIMD.Float32x4.shuffle(a2, a3, 2, 3, 6, 7);
-	  row2 = SIMD.Float32x4.shuffle(tmp1, row3, 0, 2, 4, 6);
-	  row3 = SIMD.Float32x4.shuffle(row3, tmp1, 1, 3, 5, 7);
+	  tmp1 = SH(a0, a1, 0, 1, 4, 5);
+	  row1 = SH(a2, a3, 0, 1, 4, 5);
+	  row0 = SH(tmp1, row1, 0, 2, 4, 6);
+	  row1 = SH(row1, tmp1, 1, 3, 5, 7);
+	  tmp1 = SH(a0, a1, 2, 3, 6, 7);
+	  row3 = SH(a2, a3, 2, 3, 6, 7);
+	  row2 = SH(tmp1, row3, 0, 2, 4, 6);
+	  row3 = SH(row3, tmp1, 1, 3, 5, 7);
 
-	  tmp1   = SIMD.Float32x4.mul(row2, row3);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  minor0 = SIMD.Float32x4.mul(row1, tmp1);
-	  minor1 = SIMD.Float32x4.mul(row0, tmp1);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor0 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row1, tmp1), minor0);
-	  minor1 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor1);
-	  minor1 = SIMD.Float32x4.swizzle(minor1, 2, 3, 0, 1);
+	  tmp1   = M(row2, row3);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  minor0 = M(row1, tmp1);
+	  minor1 = M(row0, tmp1);
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor0 = SUB(M(row1, tmp1), minor0);
+	  minor1 = SUB(M(row0, tmp1), minor1);
+	  minor1 = SW(minor1, 2, 3, 0, 1);
 
-	  tmp1   = SIMD.Float32x4.mul(row1, row2);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor0);
-	  minor3 = SIMD.Float32x4.mul(row0, tmp1);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row3, tmp1));
-	  minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor3);
-	  minor3 = SIMD.Float32x4.swizzle(minor3, 2, 3, 0, 1);
+	  tmp1   = M(row1, row2);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  minor0 = ADD(M(row3, tmp1), minor0);
+	  minor3 = M(row0, tmp1);
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor0 = SUB(minor0, M(row3, tmp1));
+	  minor3 = SUB(M(row0, tmp1), minor3);
+	  minor3 = SW(minor3, 2, 3, 0, 1);
 
-	  tmp1   = SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(row1, 2, 3, 0, 1), row3);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  row2   = SIMD.Float32x4.swizzle(row2, 2, 3, 0, 1);
-	  minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor0);
-	  minor2 = SIMD.Float32x4.mul(row0, tmp1);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row2, tmp1));
-	  minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor2);
-	  minor2 = SIMD.Float32x4.swizzle(minor2, 2, 3, 0, 1);
+	  tmp1   = M(SW(row1, 2, 3, 0, 1), row3);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  row2   = SW(row2, 2, 3, 0, 1);
+	  minor0 = ADD(M(row2, tmp1), minor0);
+	  minor2 = M(row0, tmp1);
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor0 = SUB(minor0, M(row2, tmp1));
+	  minor2 = SUB(M(row0, tmp1), minor2);
+	  minor2 = SW(minor2, 2, 3, 0, 1);
 
-	  tmp1   = SIMD.Float32x4.mul(row0, row1);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor2);
-	  minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row2, tmp1), minor3);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row3, tmp1), minor2);
-	  minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row2, tmp1));
+	  tmp1   = M(row0, row1);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  minor2 = ADD(M(row3, tmp1), minor2);
+	  minor3 = SUB(M(row2, tmp1), minor3);
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor2 = SUB(M(row3, tmp1), minor2);
+	  minor3 = SUB(minor3, M(row2, tmp1));
 
-	  tmp1   = SIMD.Float32x4.mul(row0, row3);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row2, tmp1));
-	  minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor2);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor1);
-	  minor2 = SIMD.Float32x4.sub(minor2, SIMD.Float32x4.mul(row1, tmp1));
+	  tmp1   = M(row0, row3);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  minor1 = SUB(minor1, M(row2, tmp1));
+	  minor2 = ADD(M(row1, tmp1), minor2);
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor1 = ADD(M(row2, tmp1), minor1);
+	  minor2 = SUB(minor2, M(row1, tmp1));
 
-	  tmp1   = SIMD.Float32x4.mul(row0, row2);
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2);
-	  minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor1);
-	  minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row1, tmp1));
-	  tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1);
-	  minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row3, tmp1));
-	  minor3 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor3);
+	  tmp1   = M(row0, row2);
+	  tmp1   = SW(tmp1, 1, 0, 3, 2);
+	  minor1 = ADD(M(row3, tmp1), minor1);
+	  minor3 = SUB(minor3, M(row1, tmp1));
+	  tmp1   = SW(tmp1, 2, 3, 0, 1);
+	  minor1 = SUB(minor1, M(row3, tmp1));
+	  minor3 = ADD(M(row1, tmp1), minor3);
 
 	  // Compute matrix determinant
-	  det   = SIMD.Float32x4.mul(row0, minor0);
-	  det   = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 2, 3, 0, 1), det);
-	  det   = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 1, 0, 3, 2), det);
+	  det   = M(row0, minor0);
+	  det   = ADD(SW(det, 2, 3, 0, 1), det);
+	  det   = ADD(SW(det, 1, 0, 3, 2), det);
 	  tmp1  = SIMD.Float32x4.reciprocalApproximation(det);
-	  det   = SIMD.Float32x4.sub(
-	               SIMD.Float32x4.add(tmp1, tmp1),
-	               SIMD.Float32x4.mul(det, SIMD.Float32x4.mul(tmp1, tmp1)));
-	  det   = SIMD.Float32x4.swizzle(det, 0, 0, 0, 0);
+	  det   = SUB(
+	               ADD(tmp1, tmp1),
+	               M(det, M(tmp1, tmp1)));
+	  det   = SW(det, 0, 0, 0, 0);
 	  if (!det) {
 	      return null;
 	  }
 
 	  // Compute matrix inverse
-	  SIMD.Float32x4.store(out, 0,  SIMD.Float32x4.mul(det, minor0));
-	  SIMD.Float32x4.store(out, 4,  SIMD.Float32x4.mul(det, minor1));
-	  SIMD.Float32x4.store(out, 8,  SIMD.Float32x4.mul(det, minor2));
-	  SIMD.Float32x4.store(out, 12, SIMD.Float32x4.mul(det, minor3));
+	  STORE(out, 0,  SIMD.Float32x4.mul(det, minor0));
+	  STORE(out, 4,  SIMD.Float32x4.mul(det, minor1));
+	  STORE(out, 8,  SIMD.Float32x4.mul(det, minor2));
+	  STORE(out, 12, SIMD.Float32x4.mul(det, minor3));
 	  return out;
 	}
 


### PR DESCRIPTION
Hi again,

So I've been looking at why we need so many iterations before getting the benefits of IonMonkey. Sorry for that messy PR, only the 4th commit is of interest for this issue https://github.com/sajjadt/simdjs-gl-matrix-bench/commit/8e0b62d7c35a45b689a68389a88f0faf814ee0da .

Ion uses heuristics to decide whether when to compile a function and when to inline it. One of these heuristics, which is used in both cases (compiling and inlining), is the bytecode size of a function. If a function has more bytecode than a given threshold, it won't get compiled / inlined in another function. The caller of invert is very hot, so we try quite early to inline it. But as the mat4.SIMD.invert function is very large (it has so much bytecode, because every time you do `SIMD.Float32x4.add(x, y)`, you have several GETPROP (aka GetProperty) opcodes (one for Float32x4 on SIMD, one for add on Float32x4). You can avoid one of them by aliasing SIMD.Float32x4.add into a local variable, and then call this variable. This reduces the size of bytecode a bit, allowing it to be compiled / inlined earlier. If I manually disable the bytecode heuristic in Ion's inlining decision code, the speedup occurs quite earlier.

Note that this is also beneficial to v8 when they'll have SIMD, because v8 has an heuristic that depends on the number of characters inside a function (a function with too many characters won't be inlined and/or compiled).

This is also a bad heuristic in IonMonkey which also affected `Math.fround` a year or two ago. We need to do something about it. I'll file a bug in Bugzilla.
